### PR TITLE
Assign unique values to ids to avoid unwanted Apollo cache dedups.

### DIFF
--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -12,6 +12,7 @@ export type Scalars = {
 /** An entity that will be a mapped typed */
 export type Author = {
    __typename?: 'Author';
+  id: Scalars['ID'];
   name: Scalars['String'];
   summary: AuthorSummary;
   popularity: Popularity;
@@ -88,6 +89,7 @@ export type AuthorOptions = DeepPartial<Author>;
 export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any> = {}): Author {
   const o = (cache["Author"] = {} as Author);
   o.__typename = "Author";
+  o.id = options.id ?? nextFactoryId("Author");
   o.name = options.name ?? "name";
   o.summary = maybeNewAuthorSummary(options.summary, cache);
   o.popularity = options.popularity ?? Popularity.Low;
@@ -228,3 +230,15 @@ type DeepPartial<T> = T extends Builtin
   : T extends {}
   ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
+
+let nextFactoryIds: Record<string, number> = {};
+
+export function resetFactoryIds() {
+  nextFactoryIds = {};
+}
+
+function nextFactoryId(objectName: string): string {
+  const nextId = nextFactoryIds[objectName] || 1;
+  nextFactoryIds[objectName] = nextId + 1;
+  return String(nextId);
+}

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -1,4 +1,4 @@
-import { newAuthor } from "./graphql-types";
+import { newAuthor, resetFactoryIds } from "./graphql-types";
 
 describe("typescript-factories", () => {
   it("does not infinite loop", () => {
@@ -15,5 +15,16 @@ describe("typescript-factories", () => {
     expect(a.__typename).toEqual("Author");
     expect(a.summary.__typename).toEqual("AuthorSummary");
     expect(a.books[0].__typename).toEqual("Book");
+  });
+
+  it("creates unique ids", () => {
+    resetFactoryIds();
+    const a1 = newAuthor({});
+    const a2 = newAuthor({});
+    expect(a1.id).toEqual("1");
+    expect(a2.id).toEqual("2");
+    resetFactoryIds();
+    const a3 = newAuthor({});
+    expect(a3.id).toEqual("1");
   });
 });

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -1,5 +1,6 @@
 # An entity that will be a mapped typed
 type Author {
+  id: ID!
   name: String!
   summary: AuthorSummary!
   popularity: Popularity!

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export const plugin: PluginFunction = async (schema, documents) => {
   generateFactoryFunctions(schema, chunks);
   generateEnumDetailHelperFunctions(schema, chunks);
   addDeepPartial(chunks);
+  addNextIdMethods(chunks);
   const content = await code`${chunks}`.toStringWithImports();
   return { content } as PluginOutput;
 };
@@ -180,7 +181,7 @@ function getInitializer(
         return `"${field.name}"`;
       }
     } else if (type.name === "ID") {
-      return `"0"`;
+      return `nextFactoryId("${object.name}")`;
     }
     // TODO Handle other scalars like dates/etc
     return `"" as any`;
@@ -233,4 +234,21 @@ function addDeepPartial(chunks: Code[]): void {
       ? { [K in keyof T]?: DeepPartial<T[K]> }
       : Partial<T>;
   `);
+}
+
+function addNextIdMethods(chunks: Code[]) : void {
+  chunks.push(code`
+    let nextFactoryIds: Record<string, number> = {};
+
+    export function resetFactoryIds() {
+      nextFactoryIds = {};
+    }
+
+    function nextFactoryId(objectName: string): string {
+      const nextId = nextFactoryIds[objectName] || 1;
+      nextFactoryIds[objectName] = nextId + 1;
+      return String(nextId);
+    }
+  `);
+
 }


### PR DESCRIPTION
Otherwise you think you're creating two line items, but Apollo "helpfully" combines them into a single line item for you.