### PR TITLE
Update the enumOrDetailOf methods to handle extra fields

### DIFF
--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -433,7 +433,7 @@ function enumOrDetailOfPopularity(enumOrDetail: PopularityDetailOptions | Popula
       code: enumOrDetail.code!,
       name: enumDetailNameOfPopularity[enumOrDetail.code!],
       ...enumOrDetail,
-    };
+    } as PopularityDetail;
   } else {
     return newPopularityDetail({
       code: enumOrDetail as Popularity,
@@ -445,24 +445,12 @@ function enumOrDetailOfPopularity(enumOrDetail: PopularityDetailOptions | Popula
 function enumOrDetailOrNullOfPopularity(
   enumOrDetail: PopularityDetailOptions | Popularity | undefined | null,
 ): PopularityDetail | null {
-  if (enumOrDetail === undefined) {
-    return newPopularityDetail();
-  } else if (enumOrDetail === null) {
+  if (enumOrDetail === null) {
     return null;
-  } else if (typeof enumOrDetail === "object" && "code" in enumOrDetail) {
-    return {
-      __typename: "PopularityDetail",
-      code: enumOrDetail.code!,
-      name: enumDetailNameOfPopularity[enumOrDetail.code!],
-      ...enumOrDetail,
-    };
-  } else {
-    return newPopularityDetail({
-      code: enumOrDetail as Popularity,
-      name: enumDetailNameOfPopularity[enumOrDetail as Popularity],
-    });
   }
+  return enumOrDetailOfPopularity(enumOrDetail);
 }
+
 const enumDetailNameOfWorking = {
   YES: "Yes",
   NO: "No",
@@ -477,7 +465,7 @@ function enumOrDetailOfWorking(enumOrDetail: WorkingDetailOptions | Working | un
       code: enumOrDetail.code!,
       name: enumDetailNameOfWorking[enumOrDetail.code!],
       ...enumOrDetail,
-    };
+    } as WorkingDetail;
   } else {
     return newWorkingDetail({
       code: enumOrDetail as Working,
@@ -489,24 +477,12 @@ function enumOrDetailOfWorking(enumOrDetail: WorkingDetailOptions | Working | un
 function enumOrDetailOrNullOfWorking(
   enumOrDetail: WorkingDetailOptions | Working | undefined | null,
 ): WorkingDetail | null {
-  if (enumOrDetail === undefined) {
-    return newWorkingDetail();
-  } else if (enumOrDetail === null) {
+  if (enumOrDetail === null) {
     return null;
-  } else if (typeof enumOrDetail === "object" && "code" in enumOrDetail) {
-    return {
-      __typename: "WorkingDetail",
-      code: enumOrDetail.code!,
-      name: enumDetailNameOfWorking[enumOrDetail.code!],
-      ...enumOrDetail,
-    };
-  } else {
-    return newWorkingDetail({
-      code: enumOrDetail as Working,
-      name: enumDetailNameOfWorking[enumOrDetail as Working],
-    });
   }
+  return enumOrDetailOfWorking(enumOrDetail);
 }
+
 let nextFactoryIds: Record<string, number> = {};
 
 export function resetFactoryIds() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ function generateEnumDetailHelperFunctions(schema: GraphQLSchema, chunks: Code[]
             code: enumOrDetail.code!,
             name: enumDetailNameOf${enumType.name}[enumOrDetail.code!],
             ...enumOrDetail,
-          }
+          } as ${type.name}
         } else {
           return new${type.name}({
             code: enumOrDetail as ${enumType.name},
@@ -95,24 +95,12 @@ function generateEnumDetailHelperFunctions(schema: GraphQLSchema, chunks: Code[]
       }
 
       function enumOrDetailOrNullOf${enumType.name}(enumOrDetail: ${enumOrDetail} | null): ${type.name} | null {
-        if (enumOrDetail === undefined) {
-          return new${type.name}();
-        } else if (enumOrDetail === null) {
+        if (enumOrDetail === null) {
           return null;
-        } else if (typeof enumOrDetail === "object" && "code" in enumOrDetail) {
-          return {
-            __typename: "${type.name}",
-            code: enumOrDetail.code!,
-            name: enumDetailNameOf${enumType.name}[enumOrDetail.code!],
-            ...enumOrDetail,
-          }
-        } else {
-          return new${type.name}({
-            code: enumOrDetail as ${enumType.name},
-            name: enumDetailNameOf${enumType.name}[enumOrDetail as ${enumType.name}],
-          });
         }
-      }`);
+        return enumOrDetailOf${enumType.name}(enumOrDetail);
+      }
+    `);
   });
 }
 


### PR DESCRIPTION
Missed a typescript error relating to the missing extra fields in the `enumOrDetailOf[TYPE]` methods.

For now, I'm just casting it `as [DETAIL_TYPE]`, since really the user will need to provide those extra fields if they actually care about them for their test.