### PR TITLE
Support tagged ids

### DIFF
--- a/integration/graphql-codegen.yml
+++ b/integration/graphql-codegen.yml
@@ -5,6 +5,8 @@ generates:
     config:
       scalarDefaults:
         Date: "./testData#newDate"
+      taggedIds:
+        AuthorSummary: "summary"
     plugins:
       - typescript
       - typescript-operations

--- a/integration/graphql-types.ts
+++ b/integration/graphql-types.ts
@@ -30,6 +30,7 @@ export type AuthorInput = {
 
 export type AuthorSummary = {
   __typename?: 'AuthorSummary';
+  id: Scalars['ID'];
   author: Author;
   numberOfBooks: Scalars['Int'];
   amountOfSales?: Maybe<Scalars['Float']>;
@@ -170,6 +171,7 @@ function maybeNewOrNullAuthor(value: AuthorOptions | undefined | null, cache: Re
 }
 export interface AuthorSummaryOptions {
   __typename?: "AuthorSummary";
+  id?: AuthorSummary["id"];
   author?: AuthorOptions;
   numberOfBooks?: AuthorSummary["numberOfBooks"];
   amountOfSales?: AuthorSummary["amountOfSales"];
@@ -178,6 +180,7 @@ export interface AuthorSummaryOptions {
 export function newAuthorSummary(options: AuthorSummaryOptions = {}, cache: Record<string, any> = {}): AuthorSummary {
   const o = (cache["AuthorSummary"] = {} as AuthorSummary);
   o.__typename = "AuthorSummary";
+  o.id = options.id ?? nextFactoryId("AuthorSummary");
   o.author = maybeNewAuthor(options.author, cache, options.hasOwnProperty("author"));
   o.numberOfBooks = options.numberOfBooks ?? 0;
   o.amountOfSales = options.amountOfSales ?? null;
@@ -521,6 +524,7 @@ function enumOrDetailOrNullOfWorking(
   return enumOrDetailOfWorking(enumOrDetail);
 }
 
+const taggedIds: Record<string, string> = { AuthorSummary: "summary" };
 let nextFactoryIds: Record<string, number> = {};
 
 export function resetFactoryIds() {
@@ -530,5 +534,6 @@ export function resetFactoryIds() {
 function nextFactoryId(objectName: string): string {
   const nextId = nextFactoryIds[objectName] || 1;
   nextFactoryIds[objectName] = nextId + 1;
-  return String(nextId);
+  const tag = taggedIds[objectName] ?? objectName.replace(/[a-z]/g, "").toLowerCase();
+  return tag + ":" + nextId;
 }

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -1,5 +1,13 @@
 import { jan1 } from "./testData";
-import { newAuthor, newBook, newCalendarInterval, newChild, Popularity, resetFactoryIds } from "./graphql-types";
+import {
+  newAuthor,
+  newAuthorSummary,
+  newBook,
+  newCalendarInterval,
+  newChild,
+  Popularity,
+  resetFactoryIds,
+} from "./graphql-types";
 
 describe("typescript-factories", () => {
   it("does not infinite loop", () => {
@@ -22,11 +30,17 @@ describe("typescript-factories", () => {
     resetFactoryIds();
     const a1 = newAuthor({});
     const a2 = newAuthor({});
-    expect(a1.id).toEqual("1");
-    expect(a2.id).toEqual("2");
+    expect(a1.id).toEqual("a:1");
+    expect(a2.id).toEqual("a:2");
     resetFactoryIds();
     const a3 = newAuthor({});
-    expect(a3.id).toEqual("1");
+    expect(a3.id).toEqual("a:1");
+  });
+
+  it("creates tagged ids based on config", () => {
+    resetFactoryIds();
+    const as = newAuthorSummary({});
+    expect(as.id).toEqual("summary:1");
   });
 
   it("fills in type name of enums", () => {

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -12,6 +12,7 @@ type Author implements Named {
 
 # A DTO that is just some fields
 type AuthorSummary {
+  id: ID!
   author: Author!
   numberOfBooks: Int!
   amountOfSales: Float


### PR DESCRIPTION
TaggedIds can be provided via the graphql-codegen.yml or generated based on the objectName