### PR TITLE
fix: Apply defaults to existing instances.

### DIFF
--- a/integration/graphql-types-and-factories.ts
+++ b/integration/graphql-types-and-factories.ts
@@ -110,6 +110,13 @@ export type SaveAuthorResult = {
 
 export type SearchResult = Author | Book;
 
+export type SearchResults = {
+  __typename?: 'SearchResults';
+  result1?: Maybe<SearchResult>;
+  result2?: Maybe<Named>;
+  result3?: Maybe<Author>;
+};
+
 export enum Working {
   Yes = 'YES',
   No = 'NO'
@@ -124,6 +131,7 @@ export type WorkingDetail = {
 
 import { newDate } from "./testData";
 
+const factories: Record<string, Function> = {};
 export interface AuthorOptions {
   __typename?: "Author";
   id?: Author["id"];
@@ -137,7 +145,8 @@ export interface AuthorOptions {
 }
 
 export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any> = {}): Author {
-  const o = (cache["Author"] = {} as Author);
+  const o = (options.__typename ? options : (cache["Author"] = {})) as Author;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "Author";
   o.id = options.id ?? nextFactoryId("Author");
   o.name = options.name ?? "name";
@@ -150,11 +159,13 @@ export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any
   return o;
 }
 
+factories["Author"] = newAuthor;
+
 function maybeNewAuthor(value: AuthorOptions | undefined, cache: Record<string, any>, isSet: boolean = false): Author {
   if (value === undefined) {
     return isSet ? undefined : cache["Author"] || newAuthor({}, cache);
   } else if (value.__typename) {
-    return value as Author;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthor(value, cache);
   }
@@ -164,7 +175,7 @@ function maybeNewOrNullAuthor(value: AuthorOptions | undefined | null, cache: Re
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as Author;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthor(value, cache);
   }
@@ -178,7 +189,8 @@ export interface AuthorSummaryOptions {
 }
 
 export function newAuthorSummary(options: AuthorSummaryOptions = {}, cache: Record<string, any> = {}): AuthorSummary {
-  const o = (cache["AuthorSummary"] = {} as AuthorSummary);
+  const o = (options.__typename ? options : (cache["AuthorSummary"] = {})) as AuthorSummary;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "AuthorSummary";
   o.id = options.id ?? nextFactoryId("AuthorSummary");
   o.author = maybeNewAuthor(options.author, cache, options.hasOwnProperty("author"));
@@ -186,6 +198,8 @@ export function newAuthorSummary(options: AuthorSummaryOptions = {}, cache: Reco
   o.amountOfSales = options.amountOfSales ?? null;
   return o;
 }
+
+factories["AuthorSummary"] = newAuthorSummary;
 
 function maybeNewAuthorSummary(
   value: AuthorSummaryOptions | undefined,
@@ -195,7 +209,7 @@ function maybeNewAuthorSummary(
   if (value === undefined) {
     return isSet ? undefined : cache["AuthorSummary"] || newAuthorSummary({}, cache);
   } else if (value.__typename) {
-    return value as AuthorSummary;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthorSummary(value, cache);
   }
@@ -208,7 +222,7 @@ function maybeNewOrNullAuthorSummary(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as AuthorSummary;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthorSummary(value, cache);
   }
@@ -222,7 +236,8 @@ export interface BookOptions {
 }
 
 export function newBook(options: BookOptions = {}, cache: Record<string, any> = {}): Book {
-  const o = (cache["Book"] = {} as Book);
+  const o = (options.__typename ? options : (cache["Book"] = {})) as Book;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "Book";
   o.name = options.name ?? "name";
   o.popularity = enumOrDetailOrNullOfPopularity(options.popularity);
@@ -231,11 +246,13 @@ export function newBook(options: BookOptions = {}, cache: Record<string, any> = 
   return o;
 }
 
+factories["Book"] = newBook;
+
 function maybeNewBook(value: BookOptions | undefined, cache: Record<string, any>, isSet: boolean = false): Book {
   if (value === undefined) {
     return isSet ? undefined : cache["Book"] || newBook({}, cache);
   } else if (value.__typename) {
-    return value as Book;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBook(value, cache);
   }
@@ -245,7 +262,7 @@ function maybeNewOrNullBook(value: BookOptions | undefined | null, cache: Record
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as Book;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBook(value, cache);
   }
@@ -256,11 +273,14 @@ export interface BookReviewOptions {
 }
 
 export function newBookReview(options: BookReviewOptions = {}, cache: Record<string, any> = {}): BookReview {
-  const o = (cache["BookReview"] = {} as BookReview);
+  const o = (options.__typename ? options : (cache["BookReview"] = {})) as BookReview;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "BookReview";
   o.rating = options.rating ?? 0;
   return o;
 }
+
+factories["BookReview"] = newBookReview;
 
 function maybeNewBookReview(
   value: BookReviewOptions | undefined,
@@ -270,7 +290,7 @@ function maybeNewBookReview(
   if (value === undefined) {
     return isSet ? undefined : cache["BookReview"] || newBookReview({}, cache);
   } else if (value.__typename) {
-    return value as BookReview;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBookReview(value, cache);
   }
@@ -283,7 +303,7 @@ function maybeNewOrNullBookReview(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as BookReview;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBookReview(value, cache);
   }
@@ -298,12 +318,15 @@ export function newCalendarInterval(
   options: CalendarIntervalOptions = {},
   cache: Record<string, any> = {},
 ): CalendarInterval {
-  const o = (cache["CalendarInterval"] = {} as CalendarInterval);
+  const o = (options.__typename ? options : (cache["CalendarInterval"] = {})) as CalendarInterval;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "CalendarInterval";
   o.start = options.start ?? newDate();
   o.end = options.end ?? newDate();
   return o;
 }
+
+factories["CalendarInterval"] = newCalendarInterval;
 
 function maybeNewCalendarInterval(
   value: CalendarIntervalOptions | undefined,
@@ -313,7 +336,7 @@ function maybeNewCalendarInterval(
   if (value === undefined) {
     return isSet ? undefined : cache["CalendarInterval"] || newCalendarInterval({}, cache);
   } else if (value.__typename) {
-    return value as CalendarInterval;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newCalendarInterval(value, cache);
   }
@@ -326,7 +349,7 @@ function maybeNewOrNullCalendarInterval(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as CalendarInterval;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newCalendarInterval(value, cache);
   }
@@ -337,17 +360,20 @@ export interface ChildOptions {
 }
 
 export function newChild(options: ChildOptions = {}, cache: Record<string, any> = {}): Child {
-  const o = (cache["Child"] = {} as Child);
+  const o = (options.__typename ? options : (cache["Child"] = {})) as Child;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "Child";
   o.parent = maybeNewAuthor(options.parent, cache, options.hasOwnProperty("parent"));
   return o;
 }
 
+factories["Child"] = newChild;
+
 function maybeNewChild(value: ChildOptions | undefined, cache: Record<string, any>, isSet: boolean = false): Child {
   if (value === undefined) {
     return isSet ? undefined : cache["Child"] || newChild({}, cache);
   } else if (value.__typename) {
-    return value as Child;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newChild(value, cache);
   }
@@ -357,7 +383,7 @@ function maybeNewOrNullChild(value: ChildOptions | undefined | null, cache: Reco
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as Child;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newChild(value, cache);
   }
@@ -372,12 +398,16 @@ export function newPopularityDetail(
   options: PopularityDetailOptions = {},
   cache: Record<string, any> = {},
 ): PopularityDetail {
-  const o = (cache["PopularityDetail"] = {} as PopularityDetail);
+  const o = (options.__typename ? options : (cache["PopularityDetail"] = {})) as PopularityDetail;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "PopularityDetail";
   o.code = options.code ?? Popularity.Low;
   o.name = options.name ?? "Low";
   return o;
 }
+
+factories["PopularityDetail"] = newPopularityDetail;
+
 export interface SaveAuthorResultOptions {
   __typename?: "SaveAuthorResult";
   author?: AuthorOptions;
@@ -387,11 +417,14 @@ export function newSaveAuthorResult(
   options: SaveAuthorResultOptions = {},
   cache: Record<string, any> = {},
 ): SaveAuthorResult {
-  const o = (cache["SaveAuthorResult"] = {} as SaveAuthorResult);
+  const o = (options.__typename ? options : (cache["SaveAuthorResult"] = {})) as SaveAuthorResult;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "SaveAuthorResult";
   o.author = maybeNewAuthor(options.author, cache, options.hasOwnProperty("author"));
   return o;
 }
+
+factories["SaveAuthorResult"] = newSaveAuthorResult;
 
 function maybeNewSaveAuthorResult(
   value: SaveAuthorResultOptions | undefined,
@@ -401,7 +434,7 @@ function maybeNewSaveAuthorResult(
   if (value === undefined) {
     return isSet ? undefined : cache["SaveAuthorResult"] || newSaveAuthorResult({}, cache);
   } else if (value.__typename) {
-    return value as SaveAuthorResult;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newSaveAuthorResult(value, cache);
   }
@@ -414,9 +447,54 @@ function maybeNewOrNullSaveAuthorResult(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as SaveAuthorResult;
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newSaveAuthorResult(value, cache);
+  }
+}
+export interface SearchResultsOptions {
+  __typename?: "SearchResults";
+  result1?: SearchResults["result1"];
+  result2?: SearchResults["result2"];
+  result3?: AuthorOptions | null;
+}
+
+export function newSearchResults(options: SearchResultsOptions = {}, cache: Record<string, any> = {}): SearchResults {
+  const o = (options.__typename ? options : (cache["SearchResults"] = {})) as SearchResults;
+  (cache.all ??= new Set()).add(o);
+  o.__typename = "SearchResults";
+  o.result1 = options.result1 ?? null;
+  o.result2 = options.result2 ?? null;
+  o.result3 = maybeNewOrNullAuthor(options.result3, cache);
+  return o;
+}
+
+factories["SearchResults"] = newSearchResults;
+
+function maybeNewSearchResults(
+  value: SearchResultsOptions | undefined,
+  cache: Record<string, any>,
+  isSet: boolean = false,
+): SearchResults {
+  if (value === undefined) {
+    return isSet ? undefined : cache["SearchResults"] || newSearchResults({}, cache);
+  } else if (value.__typename) {
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+  } else {
+    return newSearchResults(value, cache);
+  }
+}
+
+function maybeNewOrNullSearchResults(
+  value: SearchResultsOptions | undefined | null,
+  cache: Record<string, any>,
+): SearchResults | null {
+  if (!value) {
+    return null;
+  } else if (value.__typename) {
+    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+  } else {
+    return newSearchResults(value, cache);
   }
 }
 export interface WorkingDetailOptions {
@@ -427,13 +505,17 @@ export interface WorkingDetailOptions {
 }
 
 export function newWorkingDetail(options: WorkingDetailOptions = {}, cache: Record<string, any> = {}): WorkingDetail {
-  const o = (cache["WorkingDetail"] = {} as WorkingDetail);
+  const o = (options.__typename ? options : (cache["WorkingDetail"] = {})) as WorkingDetail;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "WorkingDetail";
   o.code = options.code ?? Working.Yes;
   o.name = options.name ?? "Yes";
   o.extraField = options.extraField ?? 0;
   return o;
 }
+
+factories["WorkingDetail"] = newWorkingDetail;
+
 export type NamedOptions = AuthorOptions | BookOptions | PopularityDetailOptions;
 
 export type NamedType = Author | Book | PopularityDetail;

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -32,6 +32,14 @@ type BookReview {
   rating: Int!
 }
 
+type SearchResults {
+  # For testing when a type name is not concrete
+  result1: SearchResult
+  result2: Named
+  result3: Author
+}
+
+
 union SearchResult = Author | Book
 
 schema {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,8 @@ export const plugin: PluginFunction = async (schema, documents, config: Config) 
     }
   });
 
+  chunks.push(code`const factories: Record<string, Function> = {}`);
+
   generateFactoryFunctions(config, schema, interfaceImpls, chunks);
   generateInterfaceFactoryFunctions(config, interfaceImpls, chunks);
   generateEnumDetailHelperFunctions(config, schema, chunks);
@@ -161,17 +163,17 @@ function newFactory(
     }
   });
 
+  const typeImp = maybeImport(config, type.name);
+
   const factory = code`
     export interface ${type.name}Options {
       __typename?: '${type.name}';
       ${optionFields.join("\n")}
     }
 
-    export function new${type.name}(options: ${type.name}Options = {}, cache: Record<string, any> = {}): ${maybeImport(
-    config,
-    type.name,
-  )} {
-      const o = cache["${type.name}"] = {} as ${maybeImport(config, type.name)};
+    export function new${type.name}(options: ${type.name}Options = {}, cache: Record<string, any> = {}): ${typeImp} {
+      const o = (options.__typename ? options : cache["${type.name}"] = {}) as ${typeImp};
+      (cache.all ??= new Set()).add(o);
       o.__typename = '${type.name}';
       ${Object.values(type.getFields()).map((f) => {
         if (f.type instanceof GraphQLNonNull) {
@@ -203,7 +205,10 @@ function newFactory(
         }
       })}
       return o;
-    }`;
+    }
+  
+    factories["${type.name}"] = new${type.name};
+  `;
 
   const maybeFunctions = code`
 
@@ -211,7 +216,7 @@ function newFactory(
       if (value === undefined) {
         return isSet ? undefined : cache["${type.name}"] || new${type.name}({}, cache)
       } else if (value.__typename) {
-        return value as ${scopedName};
+        return cache.all.has(value) ? value : factories[value.__typename](value, cache);
       } else {
         return new${type.name}(value, cache);
       }
@@ -221,7 +226,7 @@ function newFactory(
       if (!value) {
         return null;
       } else if (value.__typename) {
-        return value as ${scopedName};
+        return cache.all.has(value) ? value : factories[value.__typename](value, cache);
       } else {
         return new${type.name}(value, cache);
       }


### PR DESCRIPTION
Previously if we saw a test instance with __typename already set,
we would stop and leave it as-is.

This was primarly to stop infinite recursion (i.e. author has a summary
that is required, which has an author that is required, which has a
summary...and repeat).

The __typename key existence was our signal that "this is an existing
factory instance, it doesn't need re-recreating".

However, this approach would break on factory calls that tried to stitch
together existing + slightly updated instances, b/c the existing
instance would bring in a __typename, so we would stop, but then the
"slightly updated" data might not pass through a factory, which would
mean it's __typename may not be set.

Which resulted in very opaque/old behavior from the Apollo Cache.

So, this fixes it, and instead we use an extra "all" set in our
existing cache param to see that "we've already touched this
instance".