### PR TITLE
fix: Add null safe cache access.

### DIFF
--- a/integration/graphql-type-factories.ts
+++ b/integration/graphql-type-factories.ts
@@ -7,6 +7,7 @@ import {
   Child,
   PopularityDetail,
   SaveAuthorResult,
+  SearchResults,
   WorkingDetail,
   Named,
   Popularity,
@@ -14,6 +15,7 @@ import {
 } from "./graphql-types-only";
 import { newDate } from "./testData";
 
+const factories: Record<string, Function> = {};
 export interface AuthorOptions {
   __typename?: "Author";
   id?: Author["id"];
@@ -24,10 +26,12 @@ export interface AuthorOptions {
   working?: Author["working"];
   birthday?: Author["birthday"];
   books?: Array<BookOptions>;
+  bookPopularities?: Array<PopularityDetailOptions>;
 }
 
 export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any> = {}): Author {
-  const o = (cache["Author"] = {} as Author);
+  const o = (options.__typename ? options : (cache["Author"] = {})) as Author;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "Author";
   o.id = options.id ?? nextFactoryId("Author");
   o.name = options.name ?? "name";
@@ -37,14 +41,17 @@ export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any
   o.working = options.working ?? null;
   o.birthday = options.birthday ?? null;
   o.books = (options.books ?? []).map((i) => maybeNewBook(i, cache, options.hasOwnProperty("books")));
+  o.bookPopularities = (options.bookPopularities ?? []).map((i) => enumOrDetailOfPopularity(i));
   return o;
 }
+
+factories["Author"] = newAuthor;
 
 function maybeNewAuthor(value: AuthorOptions | undefined, cache: Record<string, any>, isSet: boolean = false): Author {
   if (value === undefined) {
     return isSet ? undefined : cache["Author"] || newAuthor({}, cache);
   } else if (value.__typename) {
-    return value as Author;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthor(value, cache);
   }
@@ -54,7 +61,7 @@ function maybeNewOrNullAuthor(value: AuthorOptions | undefined | null, cache: Re
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as Author;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthor(value, cache);
   }
@@ -68,7 +75,8 @@ export interface AuthorSummaryOptions {
 }
 
 export function newAuthorSummary(options: AuthorSummaryOptions = {}, cache: Record<string, any> = {}): AuthorSummary {
-  const o = (cache["AuthorSummary"] = {} as AuthorSummary);
+  const o = (options.__typename ? options : (cache["AuthorSummary"] = {})) as AuthorSummary;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "AuthorSummary";
   o.id = options.id ?? nextFactoryId("AuthorSummary");
   o.author = maybeNewAuthor(options.author, cache, options.hasOwnProperty("author"));
@@ -76,6 +84,8 @@ export function newAuthorSummary(options: AuthorSummaryOptions = {}, cache: Reco
   o.amountOfSales = options.amountOfSales ?? null;
   return o;
 }
+
+factories["AuthorSummary"] = newAuthorSummary;
 
 function maybeNewAuthorSummary(
   value: AuthorSummaryOptions | undefined,
@@ -85,7 +95,7 @@ function maybeNewAuthorSummary(
   if (value === undefined) {
     return isSet ? undefined : cache["AuthorSummary"] || newAuthorSummary({}, cache);
   } else if (value.__typename) {
-    return value as AuthorSummary;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthorSummary(value, cache);
   }
@@ -98,7 +108,7 @@ function maybeNewOrNullAuthorSummary(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as AuthorSummary;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthorSummary(value, cache);
   }
@@ -112,7 +122,8 @@ export interface BookOptions {
 }
 
 export function newBook(options: BookOptions = {}, cache: Record<string, any> = {}): Book {
-  const o = (cache["Book"] = {} as Book);
+  const o = (options.__typename ? options : (cache["Book"] = {})) as Book;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "Book";
   o.name = options.name ?? "name";
   o.popularity = enumOrDetailOrNullOfPopularity(options.popularity);
@@ -121,11 +132,13 @@ export function newBook(options: BookOptions = {}, cache: Record<string, any> = 
   return o;
 }
 
+factories["Book"] = newBook;
+
 function maybeNewBook(value: BookOptions | undefined, cache: Record<string, any>, isSet: boolean = false): Book {
   if (value === undefined) {
     return isSet ? undefined : cache["Book"] || newBook({}, cache);
   } else if (value.__typename) {
-    return value as Book;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBook(value, cache);
   }
@@ -135,7 +148,7 @@ function maybeNewOrNullBook(value: BookOptions | undefined | null, cache: Record
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as Book;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBook(value, cache);
   }
@@ -146,11 +159,14 @@ export interface BookReviewOptions {
 }
 
 export function newBookReview(options: BookReviewOptions = {}, cache: Record<string, any> = {}): BookReview {
-  const o = (cache["BookReview"] = {} as BookReview);
+  const o = (options.__typename ? options : (cache["BookReview"] = {})) as BookReview;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "BookReview";
   o.rating = options.rating ?? 0;
   return o;
 }
+
+factories["BookReview"] = newBookReview;
 
 function maybeNewBookReview(
   value: BookReviewOptions | undefined,
@@ -160,7 +176,7 @@ function maybeNewBookReview(
   if (value === undefined) {
     return isSet ? undefined : cache["BookReview"] || newBookReview({}, cache);
   } else if (value.__typename) {
-    return value as BookReview;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBookReview(value, cache);
   }
@@ -173,7 +189,7 @@ function maybeNewOrNullBookReview(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as BookReview;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBookReview(value, cache);
   }
@@ -188,12 +204,15 @@ export function newCalendarInterval(
   options: CalendarIntervalOptions = {},
   cache: Record<string, any> = {},
 ): CalendarInterval {
-  const o = (cache["CalendarInterval"] = {} as CalendarInterval);
+  const o = (options.__typename ? options : (cache["CalendarInterval"] = {})) as CalendarInterval;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "CalendarInterval";
   o.start = options.start ?? newDate();
   o.end = options.end ?? newDate();
   return o;
 }
+
+factories["CalendarInterval"] = newCalendarInterval;
 
 function maybeNewCalendarInterval(
   value: CalendarIntervalOptions | undefined,
@@ -203,7 +222,7 @@ function maybeNewCalendarInterval(
   if (value === undefined) {
     return isSet ? undefined : cache["CalendarInterval"] || newCalendarInterval({}, cache);
   } else if (value.__typename) {
-    return value as CalendarInterval;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newCalendarInterval(value, cache);
   }
@@ -216,7 +235,7 @@ function maybeNewOrNullCalendarInterval(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as CalendarInterval;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newCalendarInterval(value, cache);
   }
@@ -227,17 +246,20 @@ export interface ChildOptions {
 }
 
 export function newChild(options: ChildOptions = {}, cache: Record<string, any> = {}): Child {
-  const o = (cache["Child"] = {} as Child);
+  const o = (options.__typename ? options : (cache["Child"] = {})) as Child;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "Child";
   o.parent = maybeNewAuthor(options.parent, cache, options.hasOwnProperty("parent"));
   return o;
 }
 
+factories["Child"] = newChild;
+
 function maybeNewChild(value: ChildOptions | undefined, cache: Record<string, any>, isSet: boolean = false): Child {
   if (value === undefined) {
     return isSet ? undefined : cache["Child"] || newChild({}, cache);
   } else if (value.__typename) {
-    return value as Child;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newChild(value, cache);
   }
@@ -247,7 +269,7 @@ function maybeNewOrNullChild(value: ChildOptions | undefined | null, cache: Reco
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as Child;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newChild(value, cache);
   }
@@ -262,12 +284,16 @@ export function newPopularityDetail(
   options: PopularityDetailOptions = {},
   cache: Record<string, any> = {},
 ): PopularityDetail {
-  const o = (cache["PopularityDetail"] = {} as PopularityDetail);
+  const o = (options.__typename ? options : (cache["PopularityDetail"] = {})) as PopularityDetail;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "PopularityDetail";
   o.code = options.code ?? Popularity.Low;
   o.name = options.name ?? "Low";
   return o;
 }
+
+factories["PopularityDetail"] = newPopularityDetail;
+
 export interface SaveAuthorResultOptions {
   __typename?: "SaveAuthorResult";
   author?: AuthorOptions;
@@ -277,11 +303,14 @@ export function newSaveAuthorResult(
   options: SaveAuthorResultOptions = {},
   cache: Record<string, any> = {},
 ): SaveAuthorResult {
-  const o = (cache["SaveAuthorResult"] = {} as SaveAuthorResult);
+  const o = (options.__typename ? options : (cache["SaveAuthorResult"] = {})) as SaveAuthorResult;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "SaveAuthorResult";
   o.author = maybeNewAuthor(options.author, cache, options.hasOwnProperty("author"));
   return o;
 }
+
+factories["SaveAuthorResult"] = newSaveAuthorResult;
 
 function maybeNewSaveAuthorResult(
   value: SaveAuthorResultOptions | undefined,
@@ -291,7 +320,7 @@ function maybeNewSaveAuthorResult(
   if (value === undefined) {
     return isSet ? undefined : cache["SaveAuthorResult"] || newSaveAuthorResult({}, cache);
   } else if (value.__typename) {
-    return value as SaveAuthorResult;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newSaveAuthorResult(value, cache);
   }
@@ -304,9 +333,54 @@ function maybeNewOrNullSaveAuthorResult(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return value as SaveAuthorResult;
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newSaveAuthorResult(value, cache);
+  }
+}
+export interface SearchResultsOptions {
+  __typename?: "SearchResults";
+  result1?: SearchResults["result1"];
+  result2?: SearchResults["result2"];
+  result3?: AuthorOptions | null;
+}
+
+export function newSearchResults(options: SearchResultsOptions = {}, cache: Record<string, any> = {}): SearchResults {
+  const o = (options.__typename ? options : (cache["SearchResults"] = {})) as SearchResults;
+  (cache.all ??= new Set()).add(o);
+  o.__typename = "SearchResults";
+  o.result1 = options.result1 ?? null;
+  o.result2 = options.result2 ?? null;
+  o.result3 = maybeNewOrNullAuthor(options.result3, cache);
+  return o;
+}
+
+factories["SearchResults"] = newSearchResults;
+
+function maybeNewSearchResults(
+  value: SearchResultsOptions | undefined,
+  cache: Record<string, any>,
+  isSet: boolean = false,
+): SearchResults {
+  if (value === undefined) {
+    return isSet ? undefined : cache["SearchResults"] || newSearchResults({}, cache);
+  } else if (value.__typename) {
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
+  } else {
+    return newSearchResults(value, cache);
+  }
+}
+
+function maybeNewOrNullSearchResults(
+  value: SearchResultsOptions | undefined | null,
+  cache: Record<string, any>,
+): SearchResults | null {
+  if (!value) {
+    return null;
+  } else if (value.__typename) {
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
+  } else {
+    return newSearchResults(value, cache);
   }
 }
 export interface WorkingDetailOptions {
@@ -317,13 +391,17 @@ export interface WorkingDetailOptions {
 }
 
 export function newWorkingDetail(options: WorkingDetailOptions = {}, cache: Record<string, any> = {}): WorkingDetail {
-  const o = (cache["WorkingDetail"] = {} as WorkingDetail);
+  const o = (options.__typename ? options : (cache["WorkingDetail"] = {})) as WorkingDetail;
+  (cache.all ??= new Set()).add(o);
   o.__typename = "WorkingDetail";
   o.code = options.code ?? Working.Yes;
   o.name = options.name ?? "Yes";
   o.extraField = options.extraField ?? 0;
   return o;
 }
+
+factories["WorkingDetail"] = newWorkingDetail;
+
 export type NamedOptions = AuthorOptions | BookOptions | PopularityDetailOptions;
 
 export type NamedType = Author | Book | PopularityDetail;

--- a/integration/graphql-types-and-factories.ts
+++ b/integration/graphql-types-and-factories.ts
@@ -168,7 +168,7 @@ function maybeNewAuthor(value: AuthorOptions | undefined, cache: Record<string, 
   if (value === undefined) {
     return isSet ? undefined : cache["Author"] || newAuthor({}, cache);
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthor(value, cache);
   }
@@ -178,7 +178,7 @@ function maybeNewOrNullAuthor(value: AuthorOptions | undefined | null, cache: Re
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthor(value, cache);
   }
@@ -212,7 +212,7 @@ function maybeNewAuthorSummary(
   if (value === undefined) {
     return isSet ? undefined : cache["AuthorSummary"] || newAuthorSummary({}, cache);
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthorSummary(value, cache);
   }
@@ -225,7 +225,7 @@ function maybeNewOrNullAuthorSummary(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newAuthorSummary(value, cache);
   }
@@ -255,7 +255,7 @@ function maybeNewBook(value: BookOptions | undefined, cache: Record<string, any>
   if (value === undefined) {
     return isSet ? undefined : cache["Book"] || newBook({}, cache);
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBook(value, cache);
   }
@@ -265,7 +265,7 @@ function maybeNewOrNullBook(value: BookOptions | undefined | null, cache: Record
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBook(value, cache);
   }
@@ -293,7 +293,7 @@ function maybeNewBookReview(
   if (value === undefined) {
     return isSet ? undefined : cache["BookReview"] || newBookReview({}, cache);
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBookReview(value, cache);
   }
@@ -306,7 +306,7 @@ function maybeNewOrNullBookReview(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newBookReview(value, cache);
   }
@@ -339,7 +339,7 @@ function maybeNewCalendarInterval(
   if (value === undefined) {
     return isSet ? undefined : cache["CalendarInterval"] || newCalendarInterval({}, cache);
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newCalendarInterval(value, cache);
   }
@@ -352,7 +352,7 @@ function maybeNewOrNullCalendarInterval(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newCalendarInterval(value, cache);
   }
@@ -376,7 +376,7 @@ function maybeNewChild(value: ChildOptions | undefined, cache: Record<string, an
   if (value === undefined) {
     return isSet ? undefined : cache["Child"] || newChild({}, cache);
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newChild(value, cache);
   }
@@ -386,7 +386,7 @@ function maybeNewOrNullChild(value: ChildOptions | undefined | null, cache: Reco
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newChild(value, cache);
   }
@@ -437,7 +437,7 @@ function maybeNewSaveAuthorResult(
   if (value === undefined) {
     return isSet ? undefined : cache["SaveAuthorResult"] || newSaveAuthorResult({}, cache);
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newSaveAuthorResult(value, cache);
   }
@@ -450,7 +450,7 @@ function maybeNewOrNullSaveAuthorResult(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newSaveAuthorResult(value, cache);
   }
@@ -482,7 +482,7 @@ function maybeNewSearchResults(
   if (value === undefined) {
     return isSet ? undefined : cache["SearchResults"] || newSearchResults({}, cache);
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newSearchResults(value, cache);
   }
@@ -495,7 +495,7 @@ function maybeNewOrNullSearchResults(
   if (!value) {
     return null;
   } else if (value.__typename) {
-    return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+    return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
   } else {
     return newSearchResults(value, cache);
   }

--- a/integration/graphql-types-only.ts
+++ b/integration/graphql-types-only.ts
@@ -22,6 +22,7 @@ export type Author = Named & {
   working?: Maybe<Working>;
   birthday?: Maybe<Scalars['Date']>;
   books: Array<Book>;
+  bookPopularities: Array<PopularityDetail>;
 };
 
 export type AuthorInput = {
@@ -109,6 +110,13 @@ export type SaveAuthorResult = {
 };
 
 export type SearchResult = Author | Book;
+
+export type SearchResults = {
+  __typename?: 'SearchResults';
+  result1?: Maybe<SearchResult>;
+  result2?: Maybe<Named>;
+  result3?: Maybe<Author>;
+};
 
 export enum Working {
   Yes = 'YES',

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "test": "./node_modules/.bin/jest --watch",
     "coverage": "./node_modules/.bin/jest --collectCoverage",
     "format": "prettier --write 'src/**/*.{ts,js,tsx,jsx}'",
-    "graphql-codegen": "graphql-codegen --config ./integration/graphql-codegen.yml",
-    "graphql-codegen-types-separate": "graphql-codegen --config ./integration/graphql-codegen-types-separate.yml"
+    "graphql-codegen": "graphql-codegen --config ./integration/graphql-codegen.yml && graphql-codegen --config ./integration/graphql-codegen-types-separate.yml"
   },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,7 +219,7 @@ function newFactory(
       if (value === undefined) {
         return isSet ? undefined : cache["${type.name}"] || new${type.name}({}, cache)
       } else if (value.__typename) {
-        return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+        return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
       } else {
         return new${type.name}(value, cache);
       }
@@ -229,7 +229,7 @@ function newFactory(
       if (!value) {
         return null;
       } else if (value.__typename) {
-        return cache.all.has(value) ? value : factories[value.__typename](value, cache);
+        return cache.all?.has(value) ? value : factories[value.__typename](value, cache);
       } else {
         return new${type.name}(value, cache);
       }


### PR DESCRIPTION
The way `graphql-typescript-response-factories` calls into the methods that this plugin generates, the `cache.all` key may not be set.