### PR TITLE
fix: move graphql to peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,21 @@
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.6.2",
         "change-case": "^4.1.2",
-        "graphql": "^15.5.1",
         "ts-poet": "^5.0.1"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^2.11.8",
         "@graphql-codegen/typescript-operations": "^2.5.3",
         "@types/jest": "^27.0.1",
+        "graphql": "^16.6.0",
         "husky": "^3.0.9",
         "jest": "^27.0.6",
         "prettier": "^2.7.1",
         "ts-jest": "^27.0.4",
         "typescript": "^4.8.2"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@ardatan/relay-compiler": {
@@ -4731,11 +4734,11 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
-      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-config": {
@@ -13979,9 +13982,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.5.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.1.tgz",
-      "integrity": "sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw=="
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "graphql-config": {
       "version": "4.3.5",

--- a/package.json
+++ b/package.json
@@ -11,16 +11,19 @@
     "format": "prettier --write 'src/**/*.{ts,js,tsx,jsx}'",
     "graphql-codegen": "graphql-codegen --config ./integration/graphql-codegen.yml && graphql-codegen --config ./integration/graphql-codegen-types-separate.yml"
   },
+  "peerDependencies": {
+    "graphql": "^15.0.0 || ^16.0.0"
+  },
   "dependencies": {
     "@graphql-codegen/plugin-helpers": "^2.6.2",
     "change-case": "^4.1.2",
-    "graphql": "^15.5.1",
     "ts-poet": "^5.0.1"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^2.11.8",
     "@graphql-codegen/typescript-operations": "^2.5.3",
     "@types/jest": "^27.0.1",
+    "graphql": "^16.6.0",
     "husky": "^3.0.9",
     "jest": "^27.0.6",
     "prettier": "^2.7.1",


### PR DESCRIPTION
This PR updates the `graphql` dependency from being a hard `dependency` (meaning the package manager installs it) to a `peerDependency`. This will help avoid these kinds of errors when users of this plugin upgrade between major versions:

```
> yarn graphql-codegen
(node:4752) ExperimentalWarning: stream/web is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
✔ Parse Configuration
⚠ Generate outputs
  ❯ Generate to src/generated/graphql-types.tsx
    ✔ Load GraphQL schemas
    ✔ Load GraphQL documents
    ✖ Cannot use GraphQLSchema "{ __validationErrors: [], description: undefined, extensions: { sour…
      Ensure that there is only one instance of "graphql" in the node_modules
      directory. If different versions of "graphql" are the dependencies of other
      relied on modules, use "resolutions" to ensure only one version is installed.
      https://yarnpkg.com/en/docs/selective-version-resolutions
      Duplicate "graphql" modules cannot be used at the same time since different
      versions may have different capabilities and behavior. The data from one
      version used in the function from another could produce confusing and
      spurious results.
```

This strategy is based on the official plugins, e.g.: https://github.com/dotansimha/graphql-code-generator/blob/b4ac08ee7a8131cc983731232902a0f5db27f826/packages/plugins/typescript/typescript/package.json#L22-L24

NOTE to homebounders: I'm not migrating to `yarn` or making any other improvements here because I plan to move all these plugins to a monorepo in the future (see [the shortcut ticket 🔒](https://app.shortcut.com/homebound-team/story/24192/move-graphql-codegen-plugins-to-a-monorepo-layout)).