### PR TITLE
fix: Detect enum details only in lists.

### DIFF
--- a/integration/graphql-type-factories.ts
+++ b/integration/graphql-type-factories.ts
@@ -27,7 +27,7 @@ export interface AuthorOptions {
   popularity?: PopularityDetailOptions | Popularity;
   summary?: AuthorSummaryOptions;
   working?: Author["working"];
-  workingDetail?: WorkingDetailOptions | Working;
+  workingDetail?: Array<WorkingDetailOptions>;
 }
 
 export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any> = {}): Author {
@@ -42,7 +42,7 @@ export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any
   o.popularity = enumOrDetailOfPopularity(options.popularity);
   o.summary = maybeNewAuthorSummary(options.summary, cache, options.hasOwnProperty("summary"));
   o.working = options.working ?? null;
-  o.workingDetail = enumOrDetailOfWorking(options.workingDetail);
+  o.workingDetail = (options.workingDetail ?? []).map((i) => enumOrDetailOfWorking(i));
   return o;
 }
 

--- a/integration/graphql-types-and-factories-with-enum-mapping.ts
+++ b/integration/graphql-types-and-factories-with-enum-mapping.ts
@@ -25,7 +25,7 @@ export type Author = Named & {
   popularity: PopularityDetail;
   summary: AuthorSummary;
   working?: Maybe<Working>;
-  workingDetail: WorkingDetail;
+  workingDetail: Array<WorkingDetail>;
 };
 
 export type AuthorInput = {
@@ -152,7 +152,7 @@ export interface AuthorOptions {
   popularity?: PopularityDetailOptions | Popularity;
   summary?: AuthorSummaryOptions;
   working?: Author["working"];
-  workingDetail?: WorkingDetailOptions | Working;
+  workingDetail?: Array<WorkingDetailOptions>;
 }
 
 export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any> = {}): Author {
@@ -167,7 +167,7 @@ export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any
   o.popularity = enumOrDetailOfPopularity(options.popularity);
   o.summary = maybeNewAuthorSummary(options.summary, cache, options.hasOwnProperty("summary"));
   o.working = options.working ?? null;
-  o.workingDetail = enumOrDetailOfWorking(options.workingDetail);
+  o.workingDetail = (options.workingDetail ?? []).map((i) => enumOrDetailOfWorking(i));
   return o;
 }
 

--- a/integration/graphql-types-and-factories.ts
+++ b/integration/graphql-types-and-factories.ts
@@ -25,7 +25,7 @@ export type Author = Named & {
   popularity: PopularityDetail;
   summary: AuthorSummary;
   working?: Maybe<Working>;
-  workingDetail: WorkingDetail;
+  workingDetail: Array<WorkingDetail>;
 };
 
 export type AuthorInput = {
@@ -152,7 +152,7 @@ export interface AuthorOptions {
   popularity?: PopularityDetailOptions | Popularity;
   summary?: AuthorSummaryOptions;
   working?: Author["working"];
-  workingDetail?: WorkingDetailOptions | Working;
+  workingDetail?: Array<WorkingDetailOptions>;
 }
 
 export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any> = {}): Author {
@@ -167,7 +167,7 @@ export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any
   o.popularity = enumOrDetailOfPopularity(options.popularity);
   o.summary = maybeNewAuthorSummary(options.summary, cache, options.hasOwnProperty("summary"));
   o.working = options.working ?? null;
-  o.workingDetail = enumOrDetailOfWorking(options.workingDetail);
+  o.workingDetail = (options.workingDetail ?? []).map((i) => enumOrDetailOfWorking(i));
   return o;
 }
 

--- a/integration/graphql-types-only.ts
+++ b/integration/graphql-types-only.ts
@@ -25,7 +25,7 @@ export type Author = Named & {
   popularity: PopularityDetail;
   summary: AuthorSummary;
   working?: Maybe<Working>;
-  workingDetail: WorkingDetail;
+  workingDetail: Array<WorkingDetail>;
 };
 
 export type AuthorInput = {

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -4,7 +4,8 @@ type Author implements Named {
   name: String!
   summary: AuthorSummary!
   popularity: PopularityDetail!
-  workingDetail: WorkingDetail!
+   # Example of a detail that a) has an extra field and b) is only referenced from a list
+  workingDetail: [WorkingDetail!]!
   working: Working
   birthday: Date
   books: [Book!]!

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ function generateEnumDetailHelperFunctions(config: Config, schema: GraphQLSchema
       .filter(shouldCreateFactory)
       .flatMap((type) => {
         return Object.values(type.getFields())
-          .map((f) => unwrapNotNull(f.type))
+          .map((f) => unwrapNullsAndLists(f.type))
           .filter(isEnumDetailObject);
       }),
   );
@@ -371,6 +371,20 @@ function unwrapNotNull(type: GraphQLOutputType): GraphQLOutputType {
   } else {
     return type;
   }
+}
+
+/** Unwrap `Foo!` -> `Foo` and `[Foo!]!` -> `Foo`. */
+function unwrapNullsAndLists(type: GraphQLOutputType): GraphQLOutputType {
+  if (type instanceof GraphQLNonNull) {
+    type = type.ofType;
+  }
+  if (type instanceof GraphQLList) {
+    type = type.ofType;
+  }
+  if (type instanceof GraphQLNonNull) {
+    type = type.ofType;
+  }
+  return type;
 }
 
 function shouldCreateFactory(type: GraphQLNamedType): type is GraphQLObjectType {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": false,
     "skipLibCheck": true,
+    "inlineSourceMap": true,
     "types": ["jest"],
     "outDir": "build"
   },


### PR DESCRIPTION
If an enum detail only referred to as `status: [Status!]!` and not `status: Status!` we don't realize it needed the extra enum detail wrapper.