### PR TITLE
feat: Proper handling of interface types in factory [X]Options types

### DIFF
--- a/integration/graphql-type-factories.ts
+++ b/integration/graphql-type-factories.ts
@@ -7,6 +7,7 @@ import {
   CalendarInterval,
   Child,
   Maybe,
+  Parent,
   Popularity,
   PopularityDetail,
   SaveAuthorResult,
@@ -129,18 +130,37 @@ factories["CalendarInterval"] = newCalendarInterval;
 
 export interface ChildOptions {
   __typename?: "Child";
-  parent?: Child["parent"];
+  name?: Child["name"];
+  parent?: NamedOptions;
 }
 
 export function newChild(options: ChildOptions = {}, cache: Record<string, any> = {}): Child {
   const o = (options.__typename ? options : cache["Child"] = {}) as Child;
   (cache.all ??= new Set()).add(o);
   o.__typename = "Child";
+  o.name = options.name ?? "name";
   o.parent = maybeNew("Author", options.parent, cache, options.hasOwnProperty("parent"));
   return o;
 }
 
 factories["Child"] = newChild;
+
+export interface ParentOptions {
+  __typename?: "Parent";
+  children?: Array<NamedOptions>;
+  name?: Parent["name"];
+}
+
+export function newParent(options: ParentOptions = {}, cache: Record<string, any> = {}): Parent {
+  const o = (options.__typename ? options : cache["Parent"] = {}) as Parent;
+  (cache.all ??= new Set()).add(o);
+  o.__typename = "Parent";
+  o.children = (options.children ?? []).map((i) => maybeNew("Named", i, cache, options.hasOwnProperty("children")));
+  o.name = options.name ?? "name";
+  return o;
+}
+
+factories["Parent"] = newParent;
 
 export interface PopularityDetailOptions {
   __typename?: "PopularityDetail";
@@ -183,7 +203,7 @@ factories["SaveAuthorResult"] = newSaveAuthorResult;
 export interface SearchResultsOptions {
   __typename?: "SearchResults";
   result1?: SearchResults["result1"];
-  result2?: SearchResults["result2"];
+  result2?: NamedOptions | null;
   result3?: AuthorOptions | null;
 }
 
@@ -192,7 +212,7 @@ export function newSearchResults(options: SearchResultsOptions = {}, cache: Reco
   (cache.all ??= new Set()).add(o);
   o.__typename = "SearchResults";
   o.result1 = options.result1 ?? null;
-  o.result2 = options.result2 ?? null;
+  o.result2 = maybeNewOrNull("Named", options.result2, cache);
   o.result3 = maybeNewOrNull("Author", options.result3, cache);
   return o;
 }
@@ -218,11 +238,11 @@ export function newWorkingDetail(options: WorkingDetailOptions = {}, cache: Reco
 
 factories["WorkingDetail"] = newWorkingDetail;
 
-export type NamedOptions = AuthorOptions | BookOptions | PopularityDetailOptions;
+export type NamedOptions = AuthorOptions | BookOptions | ChildOptions | ParentOptions | PopularityDetailOptions;
 
-export type NamedType = Author | Book | PopularityDetail;
+export type NamedType = Author | Book | Child | Parent | PopularityDetail;
 
-export type NamedTypeName = "Author" | "Book" | "PopularityDetail";
+export type NamedTypeName = "Author" | "Book" | "Child" | "Parent" | "PopularityDetail";
 
 factories["Named"] = newAuthor;
 

--- a/integration/graphql-types-and-factories-with-enum-mapping.ts
+++ b/integration/graphql-types-and-factories-with-enum-mapping.ts
@@ -66,8 +66,9 @@ export type CalendarInterval = {
   start: Scalars['Date']['output'];
 };
 
-export type Child = {
+export type Child = Named & {
   __typename?: 'Child';
+  name: Scalars['String']['output'];
   parent: Named;
 };
 
@@ -82,6 +83,12 @@ export type MutationSaveAuthorArgs = {
 };
 
 export type Named = {
+  name: Scalars['String']['output'];
+};
+
+export type Parent = Named & {
+  __typename?: 'Parent';
+  children: Array<Named>;
   name: Scalars['String']['output'];
 };
 
@@ -254,18 +261,37 @@ factories["CalendarInterval"] = newCalendarInterval;
 
 export interface ChildOptions {
   __typename?: "Child";
-  parent?: Child["parent"];
+  name?: Child["name"];
+  parent?: NamedOptions;
 }
 
 export function newChild(options: ChildOptions = {}, cache: Record<string, any> = {}): Child {
   const o = (options.__typename ? options : cache["Child"] = {}) as Child;
   (cache.all ??= new Set()).add(o);
   o.__typename = "Child";
+  o.name = options.name ?? "name";
   o.parent = maybeNew("Author", options.parent, cache, options.hasOwnProperty("parent"));
   return o;
 }
 
 factories["Child"] = newChild;
+
+export interface ParentOptions {
+  __typename?: "Parent";
+  children?: Array<NamedOptions>;
+  name?: Parent["name"];
+}
+
+export function newParent(options: ParentOptions = {}, cache: Record<string, any> = {}): Parent {
+  const o = (options.__typename ? options : cache["Parent"] = {}) as Parent;
+  (cache.all ??= new Set()).add(o);
+  o.__typename = "Parent";
+  o.children = (options.children ?? []).map((i) => maybeNew("Named", i, cache, options.hasOwnProperty("children")));
+  o.name = options.name ?? "name";
+  return o;
+}
+
+factories["Parent"] = newParent;
 
 export interface PopularityDetailOptions {
   __typename?: "PopularityDetail";
@@ -308,7 +334,7 @@ factories["SaveAuthorResult"] = newSaveAuthorResult;
 export interface SearchResultsOptions {
   __typename?: "SearchResults";
   result1?: SearchResults["result1"];
-  result2?: SearchResults["result2"];
+  result2?: NamedOptions | null;
   result3?: AuthorOptions | null;
 }
 
@@ -317,7 +343,7 @@ export function newSearchResults(options: SearchResultsOptions = {}, cache: Reco
   (cache.all ??= new Set()).add(o);
   o.__typename = "SearchResults";
   o.result1 = options.result1 ?? null;
-  o.result2 = options.result2 ?? null;
+  o.result2 = maybeNewOrNull("Named", options.result2, cache);
   o.result3 = maybeNewOrNull("Author", options.result3, cache);
   return o;
 }
@@ -343,11 +369,11 @@ export function newWorkingDetail(options: WorkingDetailOptions = {}, cache: Reco
 
 factories["WorkingDetail"] = newWorkingDetail;
 
-export type NamedOptions = AuthorOptions | BookOptions | PopularityDetailOptions;
+export type NamedOptions = AuthorOptions | BookOptions | ChildOptions | ParentOptions | PopularityDetailOptions;
 
-export type NamedType = Author | Book | PopularityDetail;
+export type NamedType = Author | Book | Child | Parent | PopularityDetail;
 
-export type NamedTypeName = "Author" | "Book" | "PopularityDetail";
+export type NamedTypeName = "Author" | "Book" | "Child" | "Parent" | "PopularityDetail";
 
 factories["Named"] = newAuthor;
 

--- a/integration/graphql-types-and-factories.ts
+++ b/integration/graphql-types-and-factories.ts
@@ -66,8 +66,9 @@ export type CalendarInterval = {
   start: Scalars['Date']['output'];
 };
 
-export type Child = {
+export type Child = Named & {
   __typename?: 'Child';
+  name: Scalars['String']['output'];
   parent: Named;
 };
 
@@ -82,6 +83,12 @@ export type MutationSaveAuthorArgs = {
 };
 
 export type Named = {
+  name: Scalars['String']['output'];
+};
+
+export type Parent = Named & {
+  __typename?: 'Parent';
+  children: Array<Named>;
   name: Scalars['String']['output'];
 };
 
@@ -254,18 +261,37 @@ factories["CalendarInterval"] = newCalendarInterval;
 
 export interface ChildOptions {
   __typename?: "Child";
-  parent?: Child["parent"];
+  name?: Child["name"];
+  parent?: NamedOptions;
 }
 
 export function newChild(options: ChildOptions = {}, cache: Record<string, any> = {}): Child {
   const o = (options.__typename ? options : cache["Child"] = {}) as Child;
   (cache.all ??= new Set()).add(o);
   o.__typename = "Child";
+  o.name = options.name ?? "name";
   o.parent = maybeNew("Author", options.parent, cache, options.hasOwnProperty("parent"));
   return o;
 }
 
 factories["Child"] = newChild;
+
+export interface ParentOptions {
+  __typename?: "Parent";
+  children?: Array<NamedOptions>;
+  name?: Parent["name"];
+}
+
+export function newParent(options: ParentOptions = {}, cache: Record<string, any> = {}): Parent {
+  const o = (options.__typename ? options : cache["Parent"] = {}) as Parent;
+  (cache.all ??= new Set()).add(o);
+  o.__typename = "Parent";
+  o.children = (options.children ?? []).map((i) => maybeNew("Named", i, cache, options.hasOwnProperty("children")));
+  o.name = options.name ?? "name";
+  return o;
+}
+
+factories["Parent"] = newParent;
 
 export interface PopularityDetailOptions {
   __typename?: "PopularityDetail";
@@ -308,7 +334,7 @@ factories["SaveAuthorResult"] = newSaveAuthorResult;
 export interface SearchResultsOptions {
   __typename?: "SearchResults";
   result1?: SearchResults["result1"];
-  result2?: SearchResults["result2"];
+  result2?: NamedOptions | null;
   result3?: AuthorOptions | null;
 }
 
@@ -317,7 +343,7 @@ export function newSearchResults(options: SearchResultsOptions = {}, cache: Reco
   (cache.all ??= new Set()).add(o);
   o.__typename = "SearchResults";
   o.result1 = options.result1 ?? null;
-  o.result2 = options.result2 ?? null;
+  o.result2 = maybeNewOrNull("Named", options.result2, cache);
   o.result3 = maybeNewOrNull("Author", options.result3, cache);
   return o;
 }
@@ -343,11 +369,11 @@ export function newWorkingDetail(options: WorkingDetailOptions = {}, cache: Reco
 
 factories["WorkingDetail"] = newWorkingDetail;
 
-export type NamedOptions = AuthorOptions | BookOptions | PopularityDetailOptions;
+export type NamedOptions = AuthorOptions | BookOptions | ChildOptions | ParentOptions | PopularityDetailOptions;
 
-export type NamedType = Author | Book | PopularityDetail;
+export type NamedType = Author | Book | Child | Parent | PopularityDetail;
 
-export type NamedTypeName = "Author" | "Book" | "PopularityDetail";
+export type NamedTypeName = "Author" | "Book" | "Child" | "Parent" | "PopularityDetail";
 
 factories["Named"] = newAuthor;
 

--- a/integration/graphql-types-only.ts
+++ b/integration/graphql-types-only.ts
@@ -66,8 +66,9 @@ export type CalendarInterval = {
   start: Scalars['Date']['output'];
 };
 
-export type Child = {
+export type Child = Named & {
   __typename?: 'Child';
+  name: Scalars['String']['output'];
   parent: Named;
 };
 
@@ -82,6 +83,12 @@ export type MutationSaveAuthorArgs = {
 };
 
 export type Named = {
+  name: Scalars['String']['output'];
+};
+
+export type Parent = Named & {
+  __typename?: 'Parent';
+  children: Array<Named>;
   name: Scalars['String']['output'];
 };
 

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -108,7 +108,13 @@ interface Named {
   name: String!
 }
 
-type Child {
+type Parent implements Named {
+  name: String!
+  children: [Named!]!
+}
+
+type Child implements Named {
+  name: String!
   # For testing newChild() picks newAuthor
   parent: Named!
 }


### PR DESCRIPTION
Interface types were not being handled correctly when generating fields `FooOptions`.

Changes were also needed in `newFoo` factories.