### PR TITLE
fix: [SC-59241] Only call nextFactoryId for the id column

### DIFF
--- a/integration/graphql-type-factories.ts
+++ b/integration/graphql-type-factories.ts
@@ -20,6 +20,7 @@ import { newDate } from "./testData";
 const factories: Record<string, Function> = {};
 export interface AuthorOptions {
   __typename?: "Author";
+  anotherId?: Author["anotherId"];
   birthday?: Author["birthday"];
   bookPopularities?: Array<PopularityDetailOptions>;
   books?: Array<BookOptions>;
@@ -35,6 +36,7 @@ export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any
   const o = (options.__typename ? options : cache["Author"] = {}) as Author;
   (cache.all ??= new Set()).add(o);
   o.__typename = "Author";
+  o.anotherId = options.anotherId ?? "anotherId";
   o.birthday = options.birthday ?? null;
   o.bookPopularities = (options.bookPopularities ?? []).map((i) => enumOrDetailOfPopularity(i));
   o.books = (options.books ?? []).map((i) => maybeNew("Book", i, cache, options.hasOwnProperty("books")));

--- a/integration/graphql-types-and-factories-with-enum-mapping.ts
+++ b/integration/graphql-types-and-factories-with-enum-mapping.ts
@@ -17,6 +17,7 @@ export type Scalars = {
 
 export type Author = Named & {
   __typename?: 'Author';
+  anotherId: Scalars['ID']['output'];
   birthday?: Maybe<Scalars['Date']['output']>;
   bookPopularities: Array<PopularityDetail>;
   books: Array<Book>;
@@ -151,6 +152,7 @@ import { newDate } from "./testData";
 const factories: Record<string, Function> = {};
 export interface AuthorOptions {
   __typename?: "Author";
+  anotherId?: Author["anotherId"];
   birthday?: Author["birthday"];
   bookPopularities?: Array<PopularityDetailOptions>;
   books?: Array<BookOptions>;
@@ -166,6 +168,7 @@ export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any
   const o = (options.__typename ? options : cache["Author"] = {}) as Author;
   (cache.all ??= new Set()).add(o);
   o.__typename = "Author";
+  o.anotherId = options.anotherId ?? "anotherId";
   o.birthday = options.birthday ?? null;
   o.bookPopularities = (options.bookPopularities ?? []).map((i) => enumOrDetailOfPopularity(i));
   o.books = (options.books ?? []).map((i) => maybeNew("Book", i, cache, options.hasOwnProperty("books")));

--- a/integration/graphql-types-and-factories.ts
+++ b/integration/graphql-types-and-factories.ts
@@ -17,6 +17,7 @@ export type Scalars = {
 
 export type Author = Named & {
   __typename?: 'Author';
+  anotherId: Scalars['ID']['output'];
   birthday?: Maybe<Scalars['Date']['output']>;
   bookPopularities: Array<PopularityDetail>;
   books: Array<Book>;
@@ -151,6 +152,7 @@ import { newDate } from "./testData";
 const factories: Record<string, Function> = {};
 export interface AuthorOptions {
   __typename?: "Author";
+  anotherId?: Author["anotherId"];
   birthday?: Author["birthday"];
   bookPopularities?: Array<PopularityDetailOptions>;
   books?: Array<BookOptions>;
@@ -166,6 +168,7 @@ export function newAuthor(options: AuthorOptions = {}, cache: Record<string, any
   const o = (options.__typename ? options : cache["Author"] = {}) as Author;
   (cache.all ??= new Set()).add(o);
   o.__typename = "Author";
+  o.anotherId = options.anotherId ?? "anotherId";
   o.birthday = options.birthday ?? null;
   o.bookPopularities = (options.bookPopularities ?? []).map((i) => enumOrDetailOfPopularity(i));
   o.books = (options.books ?? []).map((i) => maybeNew("Book", i, cache, options.hasOwnProperty("books")));

--- a/integration/graphql-types-only.ts
+++ b/integration/graphql-types-only.ts
@@ -17,6 +17,7 @@ export type Scalars = {
 
 export type Author = Named & {
   __typename?: 'Author';
+  anotherId: Scalars['ID']['output'];
   birthday?: Maybe<Scalars['Date']['output']>;
   bookPopularities: Array<PopularityDetail>;
   books: Array<Book>;

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -71,6 +71,9 @@ const getTests = (testType: TestType = "types-in-file") => {
       const a2 = newAuthor({});
       expect(a1.id).toEqual("a:1");
       expect(a2.id).toEqual("a:2");
+      // And does not assign other ID fields with author ids
+      expect(a1.anotherId).toEqual("anotherId");
+      expect(a2.anotherId).toEqual("anotherId");
       resetFactoryIds();
       const a3 = newAuthor({});
       expect(a3.id).toEqual("a:1");

--- a/integration/schema.graphql
+++ b/integration/schema.graphql
@@ -1,6 +1,8 @@
 # An entity that will be a mapped typed
 type Author implements Named {
   id: ID!
+  # Ensure that the newAuthor factory does not call nextFactoryId for this field
+  anotherId: ID!
   name: String!
   summary: AuthorSummary!
   popularity: PopularityDetail!

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,7 +314,11 @@ function getInitializer(
       return `0`;
     } else if (type.name === "Boolean") {
       return `false`;
-    } else if (type.name === "String") {
+    } else if (field.name === "id" && type.name === "ID") {
+      // Only call for the `id` field, since we don't want to generate new IDs if the object contains other ID fields
+      return `nextFactoryId("${object.name}")`;
+    } else if (type.name === "String" || type.name === "ID") {
+      // Treat String and ID fields the same, as long as it is not the `id: ID` field
       const maybeCode = isEnumDetailObject(object) && object.getFields()["code"];
       if (maybeCode) {
         const value = getRealEnumForEnumDetailObject(object).getValues()[0].value;
@@ -322,8 +326,6 @@ function getInitializer(
       } else {
         return `"${field.name}"`;
       }
-    } else if (type.name === "ID") {
-      return `nextFactoryId("${object.name}")`;
     }
     const defaultFromConfig = config.scalarDefaults?.[type.name];
     if (defaultFromConfig) {


### PR DESCRIPTION
If an entity has multiple fields of type `ID`, only have the factory call `nextFactoryId` for the `id: ID` column.

Avoids the issue [mentioned here](https://github.com/homebound-team/graphql-service/pull/6195/files#r1795977342)