### PR TITLE
fix: Restore cycles by default.

### DIFF
--- a/integration/graphql-type-factories.ts
+++ b/integration/graphql-type-factories.ts
@@ -24,7 +24,7 @@ import { newDate } from "./testData";
 
 const factories: Record<string, Function> = {};
 export interface FactoryOptions {
-  withCycles?: boolean;
+  avoidCycles?: boolean;
 }
 type RequireTypename<T extends { __typename?: string }> = Omit<T, "__typename"> & Required<Pick<T, "__typename">>;
 /**
@@ -46,7 +46,7 @@ type FactoryResult<T> = T extends ReadonlyArray<infer U> ? Array<FactoryResult<U
   : T;
 
 type FactoryInput<T, TOptions> = T | FactoryResult<T> | TOptions;
-type FactoryCache = Record<string, any> & { active?: Set<object>; all?: Set<object>; withCycles?: boolean };
+type FactoryCache = Record<string, any> & { active?: Set<object>; all?: Set<object>; avoidCycles?: boolean };
 export interface AuthorOptions {
   __typename?: "Author";
   anotherId?: Author["anotherId"];
@@ -585,11 +585,11 @@ function nextFactoryId(objectName: string): string {
 }
 
 function newFactoryCache(factoryOptions: FactoryOptions = {}): FactoryCache {
-  return { withCycles: factoryOptions.withCycles === true };
+  return { avoidCycles: factoryOptions.avoidCycles === true };
 }
 
 function reuseWouldCreateCycle(cache: FactoryCache, value: object): boolean {
-  return cache.withCycles !== true && cache.active?.has(value) === true;
+  return cache.avoidCycles === true && cache.active?.has(value) === true;
 }
 
 function getCachedValue(type: string, cache: FactoryCache): any {

--- a/integration/graphql-types-and-factories-with-enum-mapping.ts
+++ b/integration/graphql-types-and-factories-with-enum-mapping.ts
@@ -174,7 +174,7 @@ import { newDate } from "./testData";
 
 const factories: Record<string, Function> = {};
 export interface FactoryOptions {
-  withCycles?: boolean;
+  avoidCycles?: boolean;
 }
 type RequireTypename<T extends { __typename?: string }> = Omit<T, "__typename"> & Required<Pick<T, "__typename">>;
 /**
@@ -196,7 +196,7 @@ type FactoryResult<T> = T extends ReadonlyArray<infer U> ? Array<FactoryResult<U
   : T;
 
 type FactoryInput<T, TOptions> = T | FactoryResult<T> | TOptions;
-type FactoryCache = Record<string, any> & { active?: Set<object>; all?: Set<object>; withCycles?: boolean };
+type FactoryCache = Record<string, any> & { active?: Set<object>; all?: Set<object>; avoidCycles?: boolean };
 export interface AuthorOptions {
   __typename?: "Author";
   anotherId?: Author["anotherId"];
@@ -735,11 +735,11 @@ function nextFactoryId(objectName: string): string {
 }
 
 function newFactoryCache(factoryOptions: FactoryOptions = {}): FactoryCache {
-  return { withCycles: factoryOptions.withCycles === true };
+  return { avoidCycles: factoryOptions.avoidCycles === true };
 }
 
 function reuseWouldCreateCycle(cache: FactoryCache, value: object): boolean {
-  return cache.withCycles !== true && cache.active?.has(value) === true;
+  return cache.avoidCycles === true && cache.active?.has(value) === true;
 }
 
 function getCachedValue(type: string, cache: FactoryCache): any {

--- a/integration/graphql-types-and-factories.ts
+++ b/integration/graphql-types-and-factories.ts
@@ -174,7 +174,7 @@ import { newDate } from "./testData";
 
 const factories: Record<string, Function> = {};
 export interface FactoryOptions {
-  withCycles?: boolean;
+  avoidCycles?: boolean;
 }
 type RequireTypename<T extends { __typename?: string }> = Omit<T, "__typename"> & Required<Pick<T, "__typename">>;
 /**
@@ -196,7 +196,7 @@ type FactoryResult<T> = T extends ReadonlyArray<infer U> ? Array<FactoryResult<U
   : T;
 
 type FactoryInput<T, TOptions> = T | FactoryResult<T> | TOptions;
-type FactoryCache = Record<string, any> & { active?: Set<object>; all?: Set<object>; withCycles?: boolean };
+type FactoryCache = Record<string, any> & { active?: Set<object>; all?: Set<object>; avoidCycles?: boolean };
 export interface AuthorOptions {
   __typename?: "Author";
   anotherId?: Author["anotherId"];
@@ -735,11 +735,11 @@ function nextFactoryId(objectName: string): string {
 }
 
 function newFactoryCache(factoryOptions: FactoryOptions = {}): FactoryCache {
-  return { withCycles: factoryOptions.withCycles === true };
+  return { avoidCycles: factoryOptions.avoidCycles === true };
 }
 
 function reuseWouldCreateCycle(cache: FactoryCache, value: object): boolean {
-  return cache.withCycles !== true && cache.active?.has(value) === true;
+  return cache.avoidCycles === true && cache.active?.has(value) === true;
 }
 
 function getCachedValue(type: string, cache: FactoryCache): any {

--- a/integration/integration.test.ts
+++ b/integration/integration.test.ts
@@ -8,7 +8,7 @@ import * as TypesAndFactoriesWithEnumMapping from "./graphql-types-and-factories
 type TestType = "types-imported" | "types-in-file" | "types-in-file-with-enum-mapping";
 
 type TestFactoryOptions = {
-  withCycles?: boolean;
+  avoidCycles?: boolean;
 };
 
 type TestObject = {
@@ -53,30 +53,27 @@ const getTests = (testType: TestType = "types-in-file") => {
     resetFactoryIds,
     newSearchResults,
   }: TestObject) => {
-    it("avoids cyclic references so generated objects can be serialized", () => {
+    it("creates cyclic references by default", () => {
       const a = newAuthor({});
       expect(a.name).toEqual("name");
-      expect(a.summary.author).toBeUndefined();
+      expect(a.summary.author).toStrictEqual(a);
       expect(function () {
         JSON.stringify(a);
-      }).not.toThrow();
+      }).toThrow(TypeError);
     });
 
     it("reuses cached entities for separate siblings", () => {
       const sr = newSearchResults({ result1: {}, result2: {} });
       expect(sr.result1?.__typename).toEqual("Author");
       expect(sr.result2).toStrictEqual(sr.result1);
-      expect(function () {
-        JSON.stringify(sr);
-      }).not.toThrow();
     });
 
-    it("can opt into cyclic references", () => {
-      const a = newAuthor({}, { withCycles: true });
-      expect(a.summary.author).toStrictEqual(a);
+    it("can opt into avoiding cyclic references", () => {
+      const a = newAuthor({}, { avoidCycles: true });
+      expect(a.summary.author).toBeUndefined();
       expect(function () {
         JSON.stringify(a);
-      }).toThrow(TypeError);
+      }).not.toThrow();
     });
 
     it("auto-factories children", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export const plugin: PluginFunction = async (schema, documents, config: Config) 
   });
 
   chunks.push(code`const factories: Record<string, Function> = {};`);
-  chunks.push(code`export interface FactoryOptions { withCycles?: boolean; }`);
+  chunks.push(code`export interface FactoryOptions { avoidCycles?: boolean; }`);
   chunks.push(
     code`type RequireTypename<T extends { __typename?: string; }> = Omit<T, "__typename"> & Required<Pick<T, "__typename">>;`,
   );
@@ -61,7 +61,7 @@ export const plugin: PluginFunction = async (schema, documents, config: Config) 
     type FactoryInput<T, TOptions> = T | FactoryResult<T> | TOptions;
   `);
   chunks.push(
-    code`type FactoryCache = Record<string, any> & { active?: Set<object>; all?: Set<object>; withCycles?: boolean; };`,
+    code`type FactoryCache = Record<string, any> & { active?: Set<object>; all?: Set<object>; avoidCycles?: boolean; };`,
   );
 
   const hasFactories = generateFactoryFunctions(config, convert, schema, interfaceImpls, chunks);
@@ -293,11 +293,11 @@ function newFactory(
 function generateMaybeFunctions(chunks: Code[]): void {
   const maybeFunctions = code`
     function newFactoryCache(factoryOptions: FactoryOptions = {}): FactoryCache {
-      return { withCycles: factoryOptions.withCycles === true };
+      return { avoidCycles: factoryOptions.avoidCycles === true };
     }
 
     function reuseWouldCreateCycle(cache: FactoryCache, value: object): boolean {
-      return cache.withCycles !== true && cache.active?.has(value) === true;
+      return cache.avoidCycles === true && cache.active?.has(value) === true;
     }
 
     function getCachedValue(type: string, cache: FactoryCache): any {


### PR DESCRIPTION
Even though cycles-by-default sounds bad, it's a lesser evil than incorrect typing, i.e. rolling this out to internal-frontend broke 100+ tests that were relying on the previous cyclic behavior.